### PR TITLE
Fix permission issue with install script

### DIFF
--- a/install
+++ b/install
@@ -7,6 +7,7 @@ if [ ! -d "$HOME/.config/tormix/themes" ]; then
 	mkdir -p $HOME/.config/tormix/themes
 fi
 cp -f $dir/themes/* $HOME/.config/tormix/themes
+sudo chown -R $USER:$USER $HOME/.config/tormix
 sudo rm /usr/share/man/man1/tormix.1.gz &>/dev/null
 sudo cp -f $dir/tormix.1 /usr/share/man/man1/
 sudo gzip /usr/share/man/man1/tormix.1


### PR DESCRIPTION
As install script is run as sudo, it creates `.config/tormix/themes` directory owned by root, rendering it unusable by user.